### PR TITLE
Handles nested braces

### DIFF
--- a/src/ini.pest
+++ b/src/ini.pest
@@ -10,8 +10,9 @@ section = { header ~ eol ~ body }
 body = { (blank | pair | comment)* }
 
 // tokens
-// a name must end with a closing bracket followed by EOL
-header = @{ "[" ~ (!("]" ~ (char | eol)) ~ char)+ ~ "]" }
+// a name must end with a closing bracket followed by optional whitespace and EOL
+header = @{ "[" ~ (!header_end ~ char)+ ~ "]" }
+header_end = !{ "]" ~ eol }
 // a key may not begin with an opening bracket and may not contain an equal sign
 key = @{ (!("=" | "[") ~ char) ~ (!"=" ~ char)* }
 value = @{ char+ }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -51,6 +51,11 @@ fn trims_spaces_after_section_name() {
 }
 
 #[test]
+fn handles_nested_section_braces() {
+	compare("[[a]]", "[[a]]\n");
+}
+
+#[test]
 fn trims_spaces_before_middle_pair() {
 	compare("a=b\n  c=d\ne=f", "a=b\nc=d\ne=f\n");
 }


### PR DESCRIPTION
The editorconfig test suite has a bunch of cases where `[` and `]` need to be parsed inside a section name.  This is a small change to the parser that allows that, and a test to prevent regressions.