### PR TITLE
Parse to a vec of tokens

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+hard_tabs = true
+newline_style = "Unix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,18 +18,18 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-pest = "2.1.2"
-pest_derive = "2.1.0"
-wasm-bindgen = { version = "0.2.55", features = ["serde-serialize"] }
+pest = "2.3.0"
+pest_derive = "2.3.0"
+wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"] }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
-console_error_panic_hook = { version = "0.1.6", optional = true }
+console_error_panic_hook = { version = "0.1.7", optional = true }
 
-serde = { version = "1.0.103", features = ["derive"] }
-serde_json = "1.0.44"
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
 
 # `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
 # compared to the default allocator's ~10K. It is slower than the default
@@ -39,7 +39,7 @@ serde_json = "1.0.44"
 wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.5"
+wasm-bindgen-test = "0.3.32"
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,71 @@
 <!-- markdownlint-disable commands-show-output -->
 
 Parser for the [EditorConfig INI file format specification](https://editorconfig-specification.readthedocs.io/en/latest/#id3).
+
+## WASM
+
+To use from [Web Assembly](https://webassembly.org/), compile with:
+
+```sh
+wasm-pack build --release --target nodejs
+```
+
+and run the (limited) WASM tests with:
+
+```sh
+wasm-pack test --node
+```
+
+You can call the genereted JS wrapper with either:
+
+```js
+import { parse_to_json } from './pkg/editorconfig_ini.js'
+
+const results = parse_to_json(`
+root = true
+
+[*]
+# always use unix line endings
+end_of_line = lf
+`)
+
+// {
+//   "version": "0.1.0",
+//   "body": [
+//     { "type": "Pair", "key": "root", "value": "true" },
+//     {
+//       "type": "Section",
+//       "name": "*",
+//       "body": [
+//         { "type": "Comment", "indicator": "#", "value": "always use unix line endings" },
+//         { "type": "Pair", "key": "end_of_line", "value": "lf" }
+//       ]
+//     }
+//   ]
+// }
+```
+
+or:
+
+```js
+import { parse_to_uint32array, TokenTypes } from './pkg/editorconfig_ini.js'
+const buf = Buffer.from(`
+root = true
+
+[*]
+# always use unix line endings
+end_of_line = lf
+`, 'utf8')
+const ary = parse_to_uint32array(buf)
+
+// Array with token type, start byte offset, end byte offset for each token
+// Uint32Array(21) [
+//   TokenTypes.Key, 1, 5,
+//   TokenTypes.Value, 8, 12,
+//   TokenTypes.Section, 15, 16,
+//   TokenTypes.CommentIndicator, 18, 19,
+//   TokenTypes.CommentValue, 20, 48,
+//   TokenTypes.Key, 49, 60,
+//   TokenTypes.Value, 63, 65
+// ]
+```

--- a/src/ini.pest
+++ b/src/ini.pest
@@ -11,11 +11,14 @@ body = { (blank | pair | comment)* }
 
 // tokens
 // a name must end with a closing bracket followed by optional whitespace and EOL
-header = @{ "[" ~ (!header_end ~ char)+ ~ "]" }
+header = ${ "[" ~ header_text ~ "]" }
+header_text = @{ (!header_end ~ char)+ }
 header_end = !{ "]" ~ eol }
 // a key may not begin with an opening bracket and may not contain an equal sign
-key = @{ (!("=" | "[") ~ char) ~ (!"=" ~ char)* }
-value = @{ char+ }
+key = @{ (!("=" | "[") ~ char) ~ (!key_end ~ char)* }
+key_end = @{ (WHITESPACE* ~ "=") } // Trim key's trailing whitespace
+value = @{ (!value_end ~ char)+ }
+value_end = @{ WHITESPACE+ ~ eol } // Trim value's trailing whitespace
 
 // atomic primitives
 bom = _{ "\u{feff}" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,9 +53,9 @@ fn create_body(pair: pest::iterators::Pair<'_, Rule>) -> Vec<Item> {
 		.map(|p| match p.as_rule() {
 			Rule::section => {
 				let mut inner_rules = p.into_inner();
-				let header = String::from(inner_rules.next().unwrap().as_str());
+				let header = inner_rules.next().unwrap().into_inner().next().unwrap();
 				return Item::Section(Section {
-					name: header[1..(header.len() - 1)].to_string(),
+					name: String::from(header.as_str()),
 					body: match inner_rules.next() {
 						Some(pair) => create_body(pair),
 						_ => vec![],
@@ -312,7 +312,7 @@ pub struct Pair {
 
 impl fmt::Display for Pair {
 	fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-		writeln!(formatter, "{}={}", self.key.trim(), self.value.trim())?;
+		writeln!(formatter, "{}={}", self.key, self.value)?;
 		Ok(())
 	}
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,6 @@
 //! Integration test suite for the parse function.
 
-use editorconfig_ini::parse;
+use editorconfig_ini::{parse, parse_to_vec, TokenTypes};
 use std::str;
 
 // Whitespace tests
@@ -108,4 +108,251 @@ fn crlf_line_separators() {
 fn compare<S: Into<String>>(contents: S, expected: &str) {
 	let ast = parse(&contents.into()).unwrap();
 	assert_eq!(ast.to_string(), expected);
+}
+
+#[test]
+fn no_whitespace_vec() {
+	compare_vec(
+		"a=b",
+		&vec![(TokenTypes::Key, "a"), (TokenTypes::Value, "b")],
+	);
+}
+
+#[test]
+fn trims_spaces_around_equals_vec() {
+	compare_vec(
+		"a = b",
+		&vec![(TokenTypes::Key, "a"), (TokenTypes::Value, "b")],
+	);
+}
+
+#[test]
+fn trims_multiple_spaces_around_equals_vec() {
+	compare_vec(
+		"a  =   b",
+		&vec![(TokenTypes::Key, "a"), (TokenTypes::Value, "b")],
+	);
+}
+
+#[test]
+fn trims_spaces_before_pair_key_vec() {
+	compare_vec(
+		"  a=b",
+		&vec![(TokenTypes::Key, "a"), (TokenTypes::Value, "b")],
+	);
+}
+
+#[test]
+fn trims_spaces_after_pair_value_vec() {
+	compare_vec(
+		"a=b  ",
+		&vec![(TokenTypes::Key, "a"), (TokenTypes::Value, "b")],
+	);
+}
+
+#[test]
+fn removes_blank_lines_between_properties_vec() {
+	compare_vec(
+		"\na=b\n\nc=d",
+		&vec![
+			(TokenTypes::Key, "a"),
+			(TokenTypes::Value, "b"),
+			(TokenTypes::Key, "c"),
+			(TokenTypes::Value, "d"),
+		],
+	);
+}
+
+#[test]
+fn includes_spaces_in_section_name_vec() {
+	compare_vec("[ a b ]", &vec![(TokenTypes::Section, " a b ")])
+}
+
+#[test]
+fn trims_spaces_before_section_name_vec() {
+	compare_vec("  [a]", &vec![(TokenTypes::Section, "a")]);
+}
+
+#[test]
+fn trims_spaces_after_section_name_vec() {
+	compare_vec("[a]  ", &vec![(TokenTypes::Section, "a")]);
+}
+
+#[test]
+fn handles_nested_section_braces_vec() {
+	compare_vec("[[a]]", &vec![(TokenTypes::Section, "[a]")]);
+}
+
+#[test]
+fn trims_spaces_before_middle_pair_vec() {
+	compare_vec(
+		"a=b\n  c=d\ne=f",
+		&vec![
+			(TokenTypes::Key, "a"),
+			(TokenTypes::Value, "b"),
+			(TokenTypes::Key, "c"),
+			(TokenTypes::Value, "d"),
+			(TokenTypes::Key, "e"),
+			(TokenTypes::Value, "f"),
+		],
+	);
+}
+
+// Tests for comment parsing to vec
+
+#[test]
+fn comment_indicator_in_section_before_pair_vec() {
+	compare_vec(
+		"[a]\n;b\nc=d",
+		&vec![
+			(TokenTypes::Section, "a"),
+			(TokenTypes::CommentIndicator, ";"),
+			(TokenTypes::CommentValue, "b"),
+			(TokenTypes::Key, "c"),
+			(TokenTypes::Value, "d"),
+		],
+	);
+	compare_vec(
+		"[a]\n#b\nc=d",
+		&vec![
+			(TokenTypes::Section, "a"),
+			(TokenTypes::CommentIndicator, "#"),
+			(TokenTypes::CommentValue, "b"),
+			(TokenTypes::Key, "c"),
+			(TokenTypes::Value, "d"),
+		],
+	);
+}
+
+#[test]
+fn comment_indicator_in_section_between_pairs_vec() {
+	compare_vec(
+		"[a]\nb=c\n;d\ne=f",
+		&vec![
+			(TokenTypes::Section, "a"),
+			(TokenTypes::Key, "b"),
+			(TokenTypes::Value, "c"),
+			(TokenTypes::CommentIndicator, ";"),
+			(TokenTypes::CommentValue, "d"),
+			(TokenTypes::Key, "e"),
+			(TokenTypes::Value, "f"),
+		],
+	);
+	compare_vec(
+		"[a]\nb=c\n#d\ne=f",
+		&vec![
+			(TokenTypes::Section, "a"),
+			(TokenTypes::Key, "b"),
+			(TokenTypes::Value, "c"),
+			(TokenTypes::CommentIndicator, "#"),
+			(TokenTypes::CommentValue, "d"),
+			(TokenTypes::Key, "e"),
+			(TokenTypes::Value, "f"),
+		],
+	);
+}
+
+#[test]
+fn comment_indicator_included_in_value_vec() {
+	compare_vec(
+		"a=b; c",
+		&vec![(TokenTypes::Key, "a"), (TokenTypes::Value, "b; c")],
+	);
+	compare_vec(
+		"a=b# c",
+		&vec![(TokenTypes::Key, "a"), (TokenTypes::Value, "b# c")],
+	);
+}
+
+#[test]
+fn escaped_comment_indicator_in_value_vec() {
+	// TODO: Not sure about this one.  Why and how does the test above
+	// remove the backslash?
+	compare_vec(
+		"a=b\\;c",
+		&vec![(TokenTypes::Key, "a"), (TokenTypes::Value, "b\\;c")],
+	);
+	compare_vec(
+		"a=b\\#c",
+		&vec![(TokenTypes::Key, "a"), (TokenTypes::Value, "b\\#c")],
+	);
+}
+
+#[test]
+fn escaped_comment_indicator_in_section_name_vec() {
+	// TODO: Not sure about this one.  Why and how does the test above
+	// remove the backslash?
+	compare_vec("[a\\;b]", &vec![(TokenTypes::Section, "a\\;b")]);
+	compare_vec("[a\\#b]", &vec![(TokenTypes::Section, "a\\#b")]);
+}
+
+#[test]
+fn removes_bom_vec() {
+	compare_vec(
+		"\u{feff}a=b",
+		&vec![(TokenTypes::Key, "a"), (TokenTypes::Value, "b")],
+	);
+}
+
+#[test]
+fn crlf_line_separators_vec() {
+	compare_vec(
+		"[a]\r\nb=c",
+		&vec![
+			(TokenTypes::Section, "a"),
+			(TokenTypes::Key, "b"),
+			(TokenTypes::Value, "c"),
+		],
+	);
+}
+
+#[test]
+fn partial_section_vec() {
+	compare_vec("[foo", &vec![]);
+}
+
+// Tests for the test harness
+#[test]
+#[should_panic]
+fn compare_vec_not_enough() {
+	compare_vec("", &vec![(TokenTypes::Key, "a")]);
+}
+
+#[test]
+#[should_panic]
+fn compare_vec_too_many() {
+	compare_vec("a=b", &vec![(TokenTypes::Key, "a")]);
+}
+
+#[test]
+#[should_panic]
+fn compare_vec_wrong_token() {
+	compare_vec("a=b", &vec![(TokenTypes::Key, "a"), (TokenTypes::Key, "b")]);
+}
+
+#[test]
+#[should_panic]
+fn compare_vec_wrong_value() {
+	compare_vec(
+		"a=b",
+		&vec![(TokenTypes::Key, "a"), (TokenTypes::Value, "c")],
+	);
+}
+
+fn compare_vec<S: Into<String>>(contents: S, expected: &Vec<(TokenTypes, &str)>) {
+	let s: String = contents.into();
+	let v = parse_to_vec(&s).unwrap();
+	let buf = s.as_bytes();
+
+	let mut i = 0;
+	for chunk in v.chunks(3) {
+		let (etyp, estr) = expected[i];
+		assert_eq!(chunk[0], etyp as u32);
+		assert_eq!(
+			str::from_utf8(&buf[chunk[1] as usize..chunk[2] as usize]).unwrap(),
+			estr
+		);
+		i += 1;
+	}
+	assert_eq!(i, expected.len());
 }

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -1,4 +1,4 @@
-//! Test suite for the Web and headless browsers.
+//! Test suite for Node.js
 
 #![cfg(test)]
 #![cfg(target_arch = "wasm32")]
@@ -8,8 +8,6 @@ use std::assert_eq;
 
 use editorconfig_ini::parse_to_uint32array;
 use wasm_bindgen_test::*;
-
-wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn uint32array() {


### PR DESCRIPTION
- Updated dependency versions.  Might not be necessary without a Cargo.lock, but it makes me feel better.
- Make the parser do whitespace stripping from keys and values, instead of the calling code to ensure more consistent whitespace handling.  Same for the brackets around section titles.
- Add a new output type, targeted at WASM, which is a vector of u32's.  This vector has a size that is always a multiple of 3.  For each token, the vector will have, in order, the token type, the byte offset of the start of the token, and the byte offset of the end of the token.  This is somewhat faster than serializing to JSON based on my benchmarking.

Someone who actually knows Rust should take a close look at this, since this is my first Rust code.  In particular, please be brutally honest about anything that could be better idiomatic Rust.